### PR TITLE
Chunk option error = TRUE currently does not work on GitHub actions

### DIFF
--- a/vignettes/models.Rmd
+++ b/vignettes/models.Rmd
@@ -62,14 +62,7 @@ riskratio(formula = death ~ stage + receptor,
 ```
 
 \
-However, the binomial model without starting values does not converge:
-
-```{r selectapproach2, error = TRUE}
-riskratio(formula = death ~ stage + receptor, 
-          data = breastcancer, 
-          approach = "glm")
-```
-
+However, the binomial model without starting values (`approach = "glm"`) does not converge, as expected.
 
 
 # Model comparisons


### PR DESCRIPTION
Purposeful demonstration of an error appears now to be dysfunctional in GitHub actions for Windows/Ubuntu (but still works on the Mac version). Omitting this the demonstration for now.